### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd event-calendar
 python3 -m venv venv
 ```
 ```
-source env/bin/activate
+source venv/bin/activate
 ```
 ```
 pip install -r requirements.txt


### PR DESCRIPTION
The virtual environment that is created with the previous command is venv, not env.